### PR TITLE
Use checkout circleci command instead of git clone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,7 @@ jobs:
           key: haskelldeps-{{checksum "/ws/atomspace/opencog/haskell/stack.yaml"}}-{{checksum "/ws/atomspace/opencog/haskell/opencog-atomspace.cabal"}}-{{ arch }}
           paths:
             - /ws/atomspace/opencog/haskell/.stack-work
-      - run:
-          name: Checkout AS-MOSES
-          command: git clone --depth 1 https://github.com/$CIRCLE_PROJECT_USERNAME/asmoses .
+      - checkout
       - run:
           name: CMake Configure
           command: mkdir build && cd build && cmake ..


### PR DESCRIPTION
Otherwise the master is checked out instead of the current branch