### PR TITLE
Improve evaluation allocation when fraction of nearest neighbors is very low

### DIFF
--- a/opencog/moses/optimization/hill-climbing.cc
+++ b/opencog/moses/optimization/hill-climbing.cc
@@ -704,7 +704,10 @@ size_t hill_climbing::crossover(deme_t& deme, size_t deme_size,
     // These cross-over (in the genetic sense) the
     // top-scoring one, two and three instances,respectively.
     size_t number_of_new_instances =
-        cross_top_one(deme, deme_size, num_to_make / 3,
+        cross_top_one(deme, deme_size,
+                      // Add the remainder so that it all sums up to
+                      // num_to_make in the end.
+                      num_to_make / 3 + num_to_make % 3,
                       sample_start, sample_size, base);
 
     number_of_new_instances +=

--- a/opencog/moses/optimization/hill-climbing.cc
+++ b/opencog/moses/optimization/hill-climbing.cc
@@ -166,6 +166,7 @@ void hill_climbing::operator()(deme_t& deme,
 
             number_of_new_instances =
                 crossover(deme, current_number_of_instances,
+                          number_of_new_instances,
                           prev_start, prev_size, prev_center);
 
             already_xover = true;
@@ -693,23 +694,26 @@ size_t hill_climbing::cross_top_three(deme_t& deme,
 }
 
 size_t hill_climbing::crossover(deme_t& deme, size_t deme_size,
+                                size_t max_number_of_new_instances,
                                 size_t sample_start, size_t sample_size,
                                 const instance& base) {
+    // Do not make more than the budget
+    size_t num_to_make = std::min(max_number_of_new_instances,
+                                  (size_t)hc_params.crossover_pop_size);
+
     // These cross-over (in the genetic sense) the
     // top-scoring one, two and three instances,respectively.
     size_t number_of_new_instances =
-        cross_top_one(deme, deme_size, hc_params.crossover_pop_size / 3,
+        cross_top_one(deme, deme_size, num_to_make / 3,
                       sample_start, sample_size, base);
 
     number_of_new_instances +=
         cross_top_two(deme, deme_size + number_of_new_instances,
-                      hc_params.crossover_pop_size / 3,
-                      sample_start, sample_size, base);
+                      num_to_make / 3, sample_start, sample_size, base);
 
     number_of_new_instances +=
         cross_top_three(deme, deme_size + number_of_new_instances,
-                        hc_params.crossover_pop_size / 3,
-                        sample_start, sample_size, base);
+                        num_to_make / 3, sample_start, sample_size, base);
 
     return number_of_new_instances;
 }

--- a/opencog/moses/optimization/hill-climbing.cc
+++ b/opencog/moses/optimization/hill-climbing.cc
@@ -28,6 +28,7 @@
  */
 
 #include <math.h>   // for sqrtf, cbrtf
+#include <algorithm>
 
 #include <boost/algorithm/minmax_element.hpp>
 
@@ -532,11 +533,12 @@ size_t hill_climbing::n_new_instances(size_t distance, unsigned max_evals,
 // disabled and it leads to some massive slow down because then most
 // of the computational power is spent on successive representation
 // building
-#define MINIMUM_DEME_SIZE         100
+#define MINIMUM_DEME_SIZE         100UL
 
-    // If fraction is small, just use up the rest of the cycles.
+    // If fraction is small, just use up the rest of the cycles up to
+    // MINIMUM_DEME_SIZE.
     if (number_of_new_instances < MINIMUM_DEME_SIZE)
-        number_of_new_instances = nleft;
+        number_of_new_instances = std::min(nleft, MINIMUM_DEME_SIZE);
 
     if (nleft < number_of_new_instances)
         number_of_new_instances = nleft;

--- a/opencog/moses/optimization/hill-climbing.h
+++ b/opencog/moses/optimization/hill-climbing.h
@@ -247,7 +247,9 @@ protected:
                            size_t sample_size,
                            const instance& base);
 
-    // chain the 3 crossovers methods above and return the number of new instances
+    // Chain the 3 crossovers methods above and return the number of
+    // new instances. The number of new instances should be lower or
+    // equal to max_number_of_new_instance.
     size_t crossover(deme_t& deme, size_t deme_size,
                      size_t max_number_of_new_instance,
                      size_t sample_start, size_t sample_size,

--- a/opencog/moses/optimization/hill-climbing.h
+++ b/opencog/moses/optimization/hill-climbing.h
@@ -249,6 +249,7 @@ protected:
 
     // chain the 3 crossovers methods above and return the number of new instances
     size_t crossover(deme_t& deme, size_t deme_size,
+                     size_t max_number_of_new_instance,
                      size_t sample_start, size_t sample_size,
                      const instance& base);
 


### PR DESCRIPTION
Port from https://github.com/opencog/moses/pull/95

1. Avoid nonsensical situation when the maximum number of evaluations is allocated to a deme because fraction of nearest neighbors was set very low (like 0.001) with the intention of spreading evaluations across more demes.

2. Make sure crossover does not produce more candidates than the maximum number of evaluations set by the user.