### PR TITLE
Representation bugfix

### DIFF
--- a/opencog/moses/representation/build_knobs.cc
+++ b/opencog/moses/representation/build_knobs.cc
@@ -653,18 +653,20 @@ void build_knobs::build_logical(pre_it subtree, pre_it it)
         // Insert logical and/or knobs above arguments and predicates.
         if (is_argument(*sib)) {
             logger().debug("Call add_logical_knobs for argument");
-            add_logical_knobs(subtree, _exemplar.insert_above(sib, flip), false);
+            sib = _exemplar.insert_above(sib, flip);
+            add_logical_knobs(subtree, sib, false);
         }
         else if (is_predicate(sib)) {
             logger().debug("Call add_logical_knobs for predictate");
-            add_logical_knobs(subtree, _exemplar.insert_above(sib, flip), false);
+            pre_it pit(sib);
+            sib = _exemplar.insert_above(sib, flip);
+            add_logical_knobs(subtree, sib, false);
 
             // At this time, we assume that the only predicate is
             // "greater_than_zero", and it has a single arg, which
             // is either contin or an argument, or any function
             // returning contin ... So, go and insert contin knobs
             // into that expression.
-            pre_it pit = sib;
             if (*pit == id::logical_not)  // skip over the not.
                 pit = pit.begin();
             pre_it cit = pit.begin();  // get the arg of predicate.

--- a/tests/moses/main/diversityUTest.cxxtest
+++ b/tests/moses/main/diversityUTest.cxxtest
@@ -51,13 +51,13 @@ void diversityUTest::test_diversity_5_parity_no_autoscale()
 {
 	// Define expected candidates
 	vector<scored_combo_tree> scts;
-	scts.push_back(string_to_scored_combo_tree("-9 or(and(or(and(or($1 $3) !$2) $4) or(and(!$1 !$3 $5) and(!$4 $5) $2)) and(or($1 $3) or($2 $4) !$5) and($1 $3))  [score=-9, penalized score=-13.8571434020996094, complexity=17, complexity penalty=4.85714292526245117, uniformity penalty=0]"));
-	scts.push_back(string_to_scored_combo_tree("-10 or(and(or(and(!$1 !$3) and(!$4 $5) $2) or(!$2 $4)) and(or($1 $3) or($2 $4) !$5) and($1 $3))  [score=-10, penalized score=-14.1830129623413086, complexity=14, complexity penalty=4, uniformity penalty=0.183012694120407104]"));
-	scts.push_back(string_to_scored_combo_tree("-10 or(and(or(and(!$1 !$3 !$4) and(!$4 $5) $2) or(!$2 $4)) and(or($1 $3) or($2 $4) !$5) and($1 $3))  [score=-10, penalized score=-14.4928216934204102, complexity=15, complexity penalty=4.28571462631225586, uniformity penalty=0.20710676908493042]"));
+	scts.push_back(string_to_scored_combo_tree("-9 or(and(or(and(or(and(!$3 !$4) $5) or(!$1 $2)) and($3 $4)) or(!$1 $2 $5) or($3 $4 !$5)) and(!$1 $2))  [score=-9, penalized score=-12.3333330154418945, complexity=15, complexity penalty=3.33333325386047363, uniformity penalty=0]"));
+	scts.push_back(string_to_scored_combo_tree("-10 or(and(or(and(!$3 !$4) and($3 $4) $5) or(!$1 $2) or($3 $4 !$5)) and(!$1 $2))  [score=-10, penalized score=-12.9166669845581055, complexity=12, complexity penalty=2.66666674613952637, uniformity penalty=0.25]"));
+	scts.push_back(string_to_scored_combo_tree("-10 or(and(or(and(or(and(!$3 !$4) $5) or(!$1 $2)) and($3 $4)) or($3 $4 !$5)) and(!$1 $2))  [score=-10, penalized score=-12.9166669845581055, complexity=12, complexity penalty=2.66666674613952637, uniformity penalty=0.25]"));
 
 	// Run test
 	moses_test_scored_combo_trees(
-		{"-l debug", "-c3", "-Hpa", "-m10000", "-k5", "-x1",
+		{"-l debug", "-c3", "-Hpa", "-m10000", "-k5", "-x1", "-z4.5",
 		 "--diversity-pressure=0.5", "--diversity-autoscale=0"},
 		scts);
 }

--- a/tests/moses/main/dynFeatSelUTest.cxxtest
+++ b/tests/moses/main/dynFeatSelUTest.cxxtest
@@ -45,7 +45,7 @@ public:
     // single-threaded test.
     // Expected score results:
     // -m12000 -r0 get score of -42 run-time  8 secs
-    // -m12000 -r1 get score of -29 run-time 13 secs
+    // -m12000 -r1 get score of -27 run-time 13 secs
     // -m12000 -r2 get score of -41 run-time 18 secs
     // -m12000 -r3 get score of -42 run-time  9 secs
     // -m12000 -r4 get score of -34 run-time 13 secs
@@ -60,7 +60,7 @@ public:
         // Reset the seed, so that this, and the next test, give exactly the same result.
         opencog::randGen().seed(1);
         vector<string> ans;
-        ans.push_back("and(or(and(or(and(or($16 $124 !$168 $200) !$23 !$284 !$287 !$288) and($16 $284) $184) !$22 !$273 !$282) $27) !$13)");
+        ans.push_back("and(or(and(or(and($16 !$278) and(!$23 !$181 !$284) $272) or(!$65 $70) !$273 !$282 !$287 !$288) $285) !$13)");
 
         string data_file_path("-i" + test_dir + "feat-sel.csv");
         // moses_test_score({"-Hit", 
@@ -87,7 +87,7 @@ public:
         opencog::randGen().seed(1);
 
         vector<string> ans;
-        ans.push_back("and(or(and(or(and(or($16 $124 !$168 $200) !$23 !$284 !$287 !$288) and($16 $284) $184) !$22 !$273 !$282) $27) !$13)");
+        ans.push_back("and(or(and(or(and($16 !$278) and(!$23 !$181 !$284) $272) or(!$65 $70) !$273 !$282 !$287 !$288) $285) !$13)");
 
         string data_file_path("-i" + test_dir + "feat-sel.csv");
         // moses_test_score({"-Hit", 
@@ -115,11 +115,11 @@ public:
         // Reset the seed, so that this, and the next test, give exactly the same result.
         opencog::randGen().seed(1);
         vector<scored_combo_tree> scts;
-        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36 !$59)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, uniformity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36 !$161)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, uniformity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53 !$290) and($16 !$36)) !$105) [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, uniformity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53) and($16 !$36)) or($22 !$290) !$105) [score=-33, penalized score=-36.4285736083984375, complexity=12, complexity penalty=3.42857170104980469, uniformity penalty=0]"));
-        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($16 !$23) or($16 !$36) !$22 !$30 !$53 !$290) and($16 !$36)) or($22 !$290) !$105) [score=-33, penalized score=-36.7142868041992188, complexity=13, complexity penalty=3.71428585052490234, uniformity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(!$30 !$36 !$53 !$156 !$250) $16) or(!$30 !$209) !$22 !$105)  [score=-33, penalized score=-35.8571434020996094, complexity=10, complexity penalty=2.85714292526245117, uniformity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-33 and(or(and(or($22 !$156) !$30 !$36 !$53 !$250) $16) or(and(!$36 $156) !$22) !$105)  [score=-33, penalized score=-36.1428565979003906, complexity=11, complexity penalty=3.14285731315612793, uniformity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-34 and(or(and(!$30 !$36 !$53 !$156 !$250) $16) !$22 !$105)  [score=-34, penalized score=-36.2857131958007812, complexity=8, complexity penalty=2.28571438789367676, uniformity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-34 and(or(and(!$30 !$36 !$53 !$156 !$202 !$250) $16) !$22 !$105)  [score=-34, penalized score=-36.5714302062988281, complexity=9, complexity penalty=2.57142877578735352, uniformity penalty=0]"));
+        scts.push_back(string_to_scored_combo_tree("-34 and(or(and(or($5 !$36) !$30 !$53 !$156 !$250) $16) !$22 !$105)  [score=-34, penalized score=-36.5714302062988281, complexity=9, complexity penalty=2.57142877578735352, uniformity penalty=0]"));
 
         string data_file_path("-i" + test_dir + "feat-sel.csv");
 

--- a/tests/moses/main/irisUTest.cxxtest
+++ b/tests/moses/main/irisUTest.cxxtest
@@ -65,7 +65,7 @@ public:
         moses_test_good_enough_score({"-Hit", 
                           "-uclass",
                           "-ndiv", "-nsin", "-nexp", "-nlog",
-                          "-m10000",
+                          "-m13000",
                           "-r14",  // Seems to work best ...
                           "-Z1",   // much much faster w/this flag...
                           data_file_path,
@@ -84,7 +84,7 @@ public:
         moses_test_good_enough_score({"-Hit", 
                           "-uclass",
                           "-ndiv", "-nsin", "-nexp", "-nlog",
-                          "-m10000",
+                          "-m13000",
                           "-r14",  // Seems to work best ...
                           "-j2",   // two threads
                           "-Z1",   // much much faster w/this flag...

--- a/tests/moses/main/mixedUTest.cxxtest
+++ b/tests/moses/main/mixedUTest.cxxtest
@@ -83,6 +83,8 @@ public:
         moses_test_score({"-Hit", 
                           "-upred",
                           "-nimpulse", "-nsin", "-nexp", "-nlog",
+                          "--discard-dominated=1",
+                          "--logical-perm-ratio=-0.5",
                           "-m1500000",
                           "-r10",  // Much faster with this rand seed.
                           "-z1",   // Seems to work much better with this weight...
@@ -103,6 +105,8 @@ public:
         moses_test_score({"-Hit", 
                           "-upred",
                           "-nimpulse", "-nsin", "-nexp", "-nlog",
+                          "--discard-dominated=1",
+                          "--logical-perm-ratio=-0.5",
                           "-m1500000",
                           "-j2",   // two threads
                           "-r10",   // Much faster with this rand seed.

--- a/tests/moses/main/selectionUTest.cxxtest
+++ b/tests/moses/main/selectionUTest.cxxtest
@@ -42,15 +42,17 @@ public:
         // opencog::logger().setPrintToStdoutFlag(true);
     }
 
-    void frame(string filename, string meval, bool boosting,
-               string expstr, int hamm)
+    void frame(string filename, bool boosting, string expstr,
+               int hamm, vector<string> args_ops={})
     {
         string data_file_path(test_dir + filename);
 
         // Create temp output file
-        vector<string> args = {"-i" + data_file_path, "-Hselect", meval,
+        vector<string> args = {"-i" + data_file_path, "-Hselect",
                                // "-lDEBUG",
                                "-q0.8", "-w0.9"};
+
+        args.insert(args.end(), args_ops.begin(), args_ops.end());
 
         if (boosting) args.push_back("--boost=1");
 
@@ -99,7 +101,7 @@ public:
         string expstr = "and( 0<( +($1 -1329.385)) not(0<( +($1 -1650.225))))";
         // Maximum reachable score is 28, and should be reachable in
         // about 7K evaluations.
-        frame("select.csv", "-m15000", true, expstr, 28);
+        frame("select.csv", true, expstr, 28, {"-m15000"});
     }
 
     void test_selection_de()
@@ -108,7 +110,7 @@ public:
         string expstr = "and( 0<( +($1 -1329.385)) not(0<( +($1 -1663.795))))";
         // Maximum reachable score is 12, and should be reachable in 
         // about 32K evaluations.
-        frame("select-less-dupe.csv", "-m50000", true, expstr, 12);
+        frame("select-less-dupe.csv", true, expstr, 12, {"-m50000"});
     }
 
     void test_selection_no()
@@ -117,7 +119,7 @@ public:
         string expstr = "and( 0<( +($1 -1329.385)) not(0<( +($1 -1663.795))))";
         // Maximum reachable score is 0, and should be reachable in
         // about 42K evaluations.
-        frame("select-no-dupe.csv", "-m80000", true, expstr, 0);
+        frame("select-no-dupe.csv", true, expstr, 0, {"-m80000"});
     }
 
     // -----------------------------------------------------------
@@ -129,7 +131,7 @@ public:
         // Maximum reachable score is 28.  Without boosting, as
         // compared to above, the solution is not as good: the ones
         // that are typically found have a score of -4, so 28+4 = 32
-        frame("select.csv", "-m10000", false, expstr, 32);
+        frame("select.csv", false, expstr, 32, {"-m10000"});
     }
 
     void test_selection_de_noboo()
@@ -139,7 +141,7 @@ public:
         // Maximum reachable score is 12, but, without boosting, as
         // compared to above, the solution is not as good: the ones
         // that are typically found have a score of -21, so 12+21 = 33
-        frame("select-less-dupe.csv", "-m20000", false, expstr, 33);
+        frame("select-less-dupe.csv", false, expstr, 33, {"-z3.3", "-m20000"});
     }
 
     void test_selection_no_noboo()
@@ -149,6 +151,6 @@ public:
         // Maximum reachable score is 0, but, without boosting, as
         // compared to above, the solution is not as good: the ones
         // that are typically found have a score of -21, so 0+21 = 21
-        frame("select-no-dupe.csv", "-m40000", false, expstr, 21);
+        frame("select-no-dupe.csv", false, expstr, 21, {"-z3.7", "-m40000"});
     }
 };

--- a/tests/moses/main/weightedUTest.cxxtest
+++ b/tests/moses/main/weightedUTest.cxxtest
@@ -50,6 +50,9 @@ public:
                           "-ur",
                           "-Ywgt",
                           "-m20000",
+                          "--discard-dominated=1",
+                          "-v150",
+                          "-z6",
                           data_file_path,
                           },
                           -6.1);
@@ -63,7 +66,10 @@ public:
                           "-ur",
                           "-r7",
                           "--score-weight=wgt",
-                          "-m20000",
+                          "-m8000",
+                          "--discard-dominated=1",
+                          "-v120",
+                          "-z6",
                           data_file_path,
                           },
                           -6.007);     // all 5-folds good, and 6 of the 10-folds bad.


### PR DESCRIPTION
This bug raised from incorrect usage of an iterator while constructing representation. The fix will significantly increase the size of the representation.
i:e
<pre>
and($1 $2) 
#knobs in old rep = 19  #knobs in new rep = 22

or(and($1 $2) and($1 or($1 $2)) or($1 $2))                               
#knobs in old rep = 49  #knobs in new rep = 69

or(and(!$2 !$3 or($3 !$2) or(!$1 $3)) and($3 $2) and($3 $1) and($1 $2 or($3 $1)))
#knobs in old rep = 92  #knobs in new rep = 178
</pre>

In order to work with the new rep[reach desired score in the specified number of evaluation] I had to change moses parameters on some UTests.
In most cases `--discard-dominated=1` seams to help a lot, for more complex problems increasing temperature[-v] is very helpful to avoid local optima. But @ngeiswei if you think these parameters compromise the validity of the unit tests I will be happy to fix them.