### PR TITLE
Fix test_run_majority_python (increase complexity ratio + relax)

### DIFF
--- a/tests/cython/moses/test_asmoses.py
+++ b/tests/cython/moses/test_asmoses.py
@@ -42,15 +42,13 @@ class TestMOSES:
         # assert output[0].program == b"or(and(!$1 $2) and($1 !$2)) "
 
     def test_run_majority_python(self):
-        output = self.moses.run(args="-H maj -c 2", python=True)
+        output = self.moses.run(args="-H maj -c 2 -z 100", python=True)
         assert isinstance(output[0], MosesCandidate)
         print ("In run_majority_python, the program is:\n", output[0].program)
         assert output[0].score == 0
         model = output[0].eval
         assert not model([0, 1, 0, 1, 0])
         assert model([1, 1, 0, 1, 0])
-        assert isinstance(output[1], MosesCandidate)
-        assert output[1].score == -1
 
     @raises(MosesException)
     def test_run_raise(self):


### PR DESCRIPTION
The complexity ratio was too low, creating a complexity penalty too
high for the optimal (more complex) solution to score better than
sub-optimal (simpler) solutions.

Also remove testing the second candidate as it may not necessarily
have a score of -1 (could be 0 or -2) depending on the parameters.