### PR TITLE
Add option to display labels in the combo program

### DIFF
--- a/opencog/combo/main/CMakeLists.txt
+++ b/opencog/combo/main/CMakeLists.txt
@@ -31,6 +31,7 @@ ADD_EXECUTABLE (ascombo-fmt-converter combo-fmt-converter.cc)
 TARGET_LINK_LIBRARIES(ascombo-fmt-converter
 	ascombo
 	ascomboant
+	data
 	${COGUTIL_LIBRARY}
 	${Boost_PROGRAM_OPTIONS_LIBRARY}
 )


### PR DESCRIPTION
It allows to set names to the combo variables before outputting to the new format. Convenient if the combo program had no variable names (only place holders) to that point. See  `ascombo-fmt-converter --help` for more info.